### PR TITLE
Extract Sequence abstract and add prependAll and appendAll methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
             "psalm --show-info=false"
         ],
         "phpunit": [
-            "phpunit"
+            "phpunit --color=always"
         ],
         "tests": [
             "@check-cs",

--- a/src/Collection/GenericList.php
+++ b/src/Collection/GenericList.php
@@ -9,9 +9,9 @@ use Munus\Collection\GenericList\Nil;
 
 /**
  * @template T
- * @extends Traversable<T>
+ * @extends Sequence<T>
  */
-abstract class GenericList extends Traversable
+abstract class GenericList extends Sequence
 {
     /**
      * @template U
@@ -37,7 +37,7 @@ abstract class GenericList extends Traversable
      *
      * @return GenericList<U>
      */
-    public static function ofAll(array $elements): self
+    public static function ofAll(iterable $elements): self
     {
         $list = Nil::instance();
         foreach ($elements as $element) {
@@ -179,5 +179,23 @@ abstract class GenericList extends Traversable
         }
 
         return $list;
+    }
+
+    public function appendAll(Traversable $elements)
+    {
+        if ($elements->isEmpty()) {
+            return $this;
+        }
+
+        return self::ofAll($elements)->prependAll($this);
+    }
+
+    public function prependAll(Traversable $elements)
+    {
+        if ($this->isEmpty()) {
+            return self::ofAll($elements);
+        }
+
+        return self::ofAll($elements)->reverse()->fold($this, function (self $list, $element) {return $list->prepend($element); });
     }
 }

--- a/src/Collection/Iterator.php
+++ b/src/Collection/Iterator.php
@@ -59,6 +59,19 @@ class Iterator implements \Iterator
         return EmptyIterator::instance();
     }
 
+    public static function fromIterable(iterable $elements): self
+    {
+        if ($elements instanceof self) {
+            return $elements;
+        }
+
+        if ($elements instanceof Traversable) {
+            return $elements->getIterator();
+        }
+
+        return new ArrayIterator($elements);
+    }
+
     public function hasNext(): bool
     {
         return !$this->current->isEmpty();

--- a/src/Collection/Iterator/ArrayIterator.php
+++ b/src/Collection/Iterator/ArrayIterator.php
@@ -9,6 +9,7 @@ use Munus\Exception\NoSuchElementException;
 
 /**
  * @template T
+ * @template-extends Iterator<T>
  */
 final class ArrayIterator extends Iterator
 {
@@ -40,6 +41,15 @@ final class ArrayIterator extends Iterator
     {
         if (isset($this->elements[$this->index])) {
             return $this->elements[$this->index++];
+        }
+
+        throw new NoSuchElementException();
+    }
+
+    public function current()
+    {
+        if (isset($this->elements[$this->index])) {
+            return $this->elements[$this->index];
         }
 
         throw new NoSuchElementException();

--- a/src/Collection/Iterator/CompositeIterator.php
+++ b/src/Collection/Iterator/CompositeIterator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Munus\Collection\Iterator;
+
+use Munus\Collection\Iterator;
+use Munus\Exception\NoSuchElementException;
+
+/**
+ * @template T
+ * @template-extends Iterator<T>
+ */
+final class CompositeIterator extends Iterator
+{
+    /**
+     * @var ArrayIterator<Iterator<T>>
+     */
+    private $iterators;
+
+    /**
+     * @var Iterator<T>
+     */
+    private $current;
+
+    /**
+     * @param array<int, Iterator<T>> $iterators
+     */
+    public function __construct(array $iterators)
+    {
+        $this->iterators = new ArrayIterator($iterators);
+        $this->current = $this->iterators->current();
+    }
+
+    /**
+     * @template U
+     *
+     * @param array<int, Iterator<U>> $iterators
+     *
+     * @return Iterator<U>
+     */
+    public static function of(...$iterators): Iterator
+    {
+        return new self($iterators);
+    }
+
+    public function hasNext(): bool
+    {
+        if ($this->current->hasNext()) {
+            return true;
+        }
+
+        if (!$this->iterators->hasNext()) {
+            return false;
+        }
+
+        $this->current = $this->iterators->next();
+
+        return $this->hasNext();
+    }
+
+    public function next()
+    {
+        if (!$this->hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        return $this->current->next();
+    }
+
+    public function rewind()
+    {
+        $this->iterators->rewind();
+        $this->current = $this->iterators->current();
+    }
+
+    public function current()
+    {
+        return $this->current->current();
+    }
+}

--- a/src/Collection/Iterator/SingletonIterator.php
+++ b/src/Collection/Iterator/SingletonIterator.php
@@ -48,4 +48,13 @@ final class SingletonIterator extends Iterator
 
         return $this->element;
     }
+
+    public function current()
+    {
+        if ($this->hasNext === true) {
+            return $this->element;
+        }
+
+        throw new NoSuchElementException();
+    }
 }

--- a/src/Collection/Iterator/StreamIterator.php
+++ b/src/Collection/Iterator/StreamIterator.php
@@ -28,6 +28,14 @@ final class StreamIterator extends Iterator
         $this->current = Lazy::ofValue($current);
     }
 
+    /**
+     * @return T
+     */
+    public function current()
+    {
+        return $this->current->get()->head();
+    }
+
     public function hasNext(): bool
     {
         return !$this->current->get()->isEmpty();

--- a/src/Collection/Sequence.php
+++ b/src/Collection/Sequence.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Munus\Collection;
+
+/**
+ * Sequence - immutable sequential data structures.
+ *
+ * @template T
+ * @template-extends Traversable<T>
+ */
+abstract class Sequence extends Traversable
+{
+    /**
+     * @param T $element
+     *
+     * @return self<T>
+     */
+    abstract public function append($element);
+
+    /**
+     * @param Traversable<T> $elements
+     *
+     * @return self<T>
+     */
+    abstract public function appendAll(Traversable $elements);
+
+    /**
+     * @param T $element
+     *
+     * @return self<T>
+     */
+    abstract public function prepend($element);
+
+    /**
+     * @param Traversable<T> $elements
+     *
+     * @return self<T>
+     */
+    abstract public function prependAll(Traversable $elements);
+}

--- a/src/Collection/Stream.php
+++ b/src/Collection/Stream.php
@@ -10,9 +10,9 @@ use Munus\Collection\Stream\EmptyStream;
 
 /**
  * @template T
- * @extends Traversable<T>
+ * @extends Sequence<T>
  */
-abstract class Stream extends Traversable
+abstract class Stream extends Sequence
 {
     /**
      * @template U
@@ -33,15 +33,14 @@ abstract class Stream extends Traversable
      *
      * @return Stream<U>
      */
-    public static function ofAll(array $elements): self
+    public static function ofAll(iterable $elements): self
     {
-        if (current($elements) === false) {
+        $elements = Iterator::fromIterable($elements);
+        if (!$elements->hasNext()) {
             return self::empty();
         }
 
-        return new Cons(current($elements), function () use ($elements) {
-            next($elements);
-
+        return new Cons($elements->next(), function () use ($elements) {
             return self::ofAll($elements);
         });
     }
@@ -247,5 +246,24 @@ abstract class Stream extends Traversable
         }
 
         return $collector->finish();
+    }
+
+    /**
+     * @param T $element
+     *
+     * @return Stream<T>
+     */
+    public function prepend($element)
+    {
+        return new Cons($element, function () {return $this; });
+    }
+
+    public function prependAll(Traversable $elements)
+    {
+        if ($elements->isEmpty()) {
+            return $this;
+        }
+
+        return self::ofAll($elements)->appendAll($this);
     }
 }

--- a/src/Collection/Stream/Cons.php
+++ b/src/Collection/Stream/Cons.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Munus\Collection\Stream;
 
 use Munus\Collection\Iterator;
+use Munus\Collection\Iterator\CompositeIterator;
 use Munus\Collection\Iterator\StreamIterator;
 use Munus\Collection\Stream;
+use Munus\Collection\Traversable;
 use Munus\Lazy;
 
 /**
@@ -66,5 +68,21 @@ final class Cons extends Stream
     public function iterator(): Iterator
     {
         return new StreamIterator($this);
+    }
+
+    public function append($element)
+    {
+        return new Cons($this->head, function () use ($element) {
+            return $this->tail()->append($element);
+        });
+    }
+
+    public function appendAll(Traversable $elements)
+    {
+        if ($elements->isEmpty()) {
+            return $this;
+        }
+
+        return Stream::ofAll(CompositeIterator::of($this->iterator(), $elements->iterator()));
     }
 }

--- a/src/Collection/Stream/EmptyStream.php
+++ b/src/Collection/Stream/EmptyStream.php
@@ -6,6 +6,8 @@ namespace Munus\Collection\Stream;
 
 use Munus\Collection\Iterator;
 use Munus\Collection\Stream;
+use Munus\Collection\T;
+use Munus\Collection\Traversable;
 
 /**
  * Empty is better but it is reserved keyword.
@@ -47,5 +49,19 @@ final class EmptyStream extends Stream
     public function iterator(): Iterator
     {
         return Iterator::empty();
+    }
+
+    public function append($element)
+    {
+        return Stream::of($element);
+    }
+
+    public function appendAll(Traversable $elements)
+    {
+        if ($elements->isEmpty()) {
+            return $this;
+        }
+
+        return Stream::ofAll($elements->iterator());
     }
 }

--- a/src/Collection/Traversable.php
+++ b/src/Collection/Traversable.php
@@ -16,7 +16,7 @@ use Munus\Value\Comparator;
  * @template T
  * @template-extends Value<T>
  */
-abstract class Traversable extends Value
+abstract class Traversable extends Value implements \IteratorAggregate
 {
     /**
      * Computes the number of elements of this traversable.
@@ -251,5 +251,13 @@ abstract class Traversable extends Value
         return $this->fold(0, function ($count, $value) use ($predicate) {
             return $predicate($value) === true ? ++$count : $count;
         });
+    }
+
+    /**
+     * @return Iterator<T>
+     */
+    public function getIterator()
+    {
+        return $this->iterator();
     }
 }

--- a/src/Lazy.php
+++ b/src/Lazy.php
@@ -87,6 +87,11 @@ final class Lazy extends Value
         return $this->supplier === null ? $this->value : $this->computeValue();
     }
 
+    public function __invoke()
+    {
+        return $this->get();
+    }
+
     public function iterator(): Iterator
     {
         return Iterator::of($this->get());

--- a/tests/Collection/GenericListTest.php
+++ b/tests/Collection/GenericListTest.php
@@ -167,4 +167,25 @@ final class GenericListTest extends TestCase
         );
         self::assertTrue(Stream::empty()->equals(GenericList::empty()));
     }
+
+    public function testListPrependAll(): void
+    {
+        self::assertTrue(GenericList::of(1, 2, 3)->equals(GenericList::empty()->prependAll(GenericList::of(1, 2, 3))));
+        self::assertTrue(GenericList::of(1, 2, 3, 4)->equals(GenericList::of(3, 4)->prependAll(GenericList::of(1, 2))));
+        self::assertTrue(GenericList::of('a', 'b', 'c', 'd', 'e')->equals(GenericList::of('e')->prependAll(GenericList::of('a', 'b', 'c', 'd'))));
+    }
+
+    public function testListAppendAllOnEmpty(): void
+    {
+        self::assertTrue(GenericList::of(1, 2, 3)->equals(GenericList::empty()->appendAll(GenericList::of(1, 2, 3))));
+
+        $empty = GenericList::empty();
+        self::assertSame($empty, $empty->appendAll(GenericList::empty()));
+    }
+
+    public function testListAppendAll(): void
+    {
+        self::assertTrue(GenericList::of(1, 2, 3, 4)->equals(GenericList::of(1, 2)->appendAll(GenericList::of(3, 4))));
+        self::assertTrue(GenericList::of('a', 'b', 'c', 'd', 'e')->equals(GenericList::of('a')->appendAll(GenericList::of('b', 'c', 'd', 'e'))));
+    }
 }

--- a/tests/Collection/IteratorTest.php
+++ b/tests/Collection/IteratorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Munus\Tests\Collection;
 
 use Munus\Collection\Iterator;
+use Munus\Collection\Iterator\CompositeIterator;
 use Munus\Collection\Map;
 use Munus\Exception\NoSuchElementException;
 use Munus\Tuple;
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 final class IteratorTest extends TestCase
 {
@@ -58,5 +59,18 @@ final class IteratorTest extends TestCase
 
         $this->expectException(NoSuchElementException::class);
         $iterator->next();
+    }
+
+    public function testCompositeIterator(): void
+    {
+        $iterator = new CompositeIterator([$first = Iterator::of(1), Iterator::of(2, 3), Iterator::empty(), Iterator::of(4)]);
+
+        self::assertTrue($iterator->hasNext());
+        self::assertSame(1, $iterator->current());
+        self::assertEquals(1, $iterator->next());
+        self::assertEquals(2, $iterator->next());
+        self::assertEquals(3, $iterator->next());
+        self::assertEquals(4, $iterator->next());
+        self::assertFalse($iterator->hasNext());
     }
 }

--- a/tests/Collection/StreamTest.php
+++ b/tests/Collection/StreamTest.php
@@ -17,6 +17,7 @@ final class StreamTest extends TestCase
         $iterator = Stream::ofAll([1, 2, 3])->iterator();
 
         self::assertTrue($iterator->hasNext());
+        self::assertEquals(1, $iterator->current());
         self::assertEquals(1, $iterator->next());
         self::assertEquals(2, $iterator->next());
         self::assertEquals(3, $iterator->next());
@@ -204,5 +205,38 @@ final class StreamTest extends TestCase
     {
         // is there logical use case for this?
         self::assertTrue(Stream::of(1, 2, 3)->equals(Stream::of(1, 2, 3)->toStream()));
+    }
+
+    public function testStreamPrepend(): void
+    {
+        self::assertTrue(Stream::of(1, 2, 3)->equals(Stream::of(2, 3)->prepend(1)));
+        self::assertTrue(Stream::of(1)->equals(Stream::empty()->prepend(1)));
+    }
+
+    public function testStreamAppend(): void
+    {
+        self::assertTrue(Stream::of(1, 2, 3)->equals(Stream::of(1, 2)->append(3)));
+        self::assertTrue(Stream::of(1)->equals(Stream::empty()->append(1)));
+    }
+
+    public function testStreamAppendAllOnEmpty(): void
+    {
+        self::assertTrue(Stream::of(1, 2, 3)->equals(Stream::empty()->appendAll(Stream::of(1, 2, 3))));
+
+        $empty = Stream::empty();
+        self::assertSame($empty, $empty->appendAll(Stream::empty()));
+    }
+
+    public function testStreamAppendAll(): void
+    {
+        self::assertTrue(Stream::of(1, 2, 3, 4)->equals(Stream::of(1, 2)->appendAll(Stream::of(3, 4))));
+        self::assertTrue(Stream::of('a', 'b', 'c', 'd', 'e')->equals(Stream::of('a')->appendAll(Stream::of('b', 'c', 'd', 'e'))));
+    }
+
+    public function testStreamPrependAll(): void
+    {
+        self::assertTrue(Stream::of(1, 2, 3)->equals(Stream::empty()->prependAll(Stream::of(1, 2, 3))));
+        self::assertTrue(Stream::of(1, 2, 3, 4)->equals(Stream::of(3, 4)->prependAll(Stream::of(1, 2))));
+        self::assertTrue(Stream::of('a', 'b', 'c', 'd', 'e')->equals(Stream::of('e')->prependAll(Stream::of('a', 'b', 'c', 'd'))));
     }
 }


### PR DESCRIPTION
This PR introduce BC break:
- [x] Sequence abstract for Stream and GenericList
- [x] methods `ofAll` now accepts `iterable` (prev `array`)