### PR TITLE
inconsistent return type makes psalm to crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .phpunit.result.cache
 clover.xml
 /coverage
+.idea

--- a/src/Collection/GenericList.php
+++ b/src/Collection/GenericList.php
@@ -33,7 +33,7 @@ abstract class GenericList extends Sequence
     /**
      * @template U
      *
-     * @param array<U> $elements
+     * @param iterable<U> $elements
      *
      * @return GenericList<U>
      */


### PR DESCRIPTION
Found this in my project when calling `GenericList::ofAll()`:

```php
use\Munus\Collection\GenericList;

function doSomething(iterable $collection): GenericList
{
    return GenericList::ofAll($collection);
}
```

Passing `iterable` into `GenericList::ofAll()` makes psalm crash because parameter is described as `array`. For now i suppressed psalm in place.

If I don't understand something in here and this is intentional (I noticed that psalm much more issues like this one), simply reject this PR. 