### PR TITLE
Implement ReturnTypeWillChange attribute

### DIFF
--- a/src/Collection/Iterator.php
+++ b/src/Collection/Iterator.php
@@ -8,6 +8,7 @@ use Munus\Collection\Iterator\ArrayIterator;
 use Munus\Collection\Iterator\EmptyIterator;
 use Munus\Collection\Iterator\SingletonIterator;
 use Munus\Exception\NoSuchElementException;
+use ReturnTypeWillChange;
 
 /**
  * @template T
@@ -83,6 +84,7 @@ class Iterator implements \Iterator
     /**
      * @return T
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $result = $this->current->head();
@@ -108,6 +110,7 @@ class Iterator implements \Iterator
     /**
      * @return T
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->current->head();
@@ -116,16 +119,19 @@ class Iterator implements \Iterator
     /**
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->hasNext();
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = $this->traversable;

--- a/src/Collection/Traversable.php
+++ b/src/Collection/Traversable.php
@@ -8,6 +8,7 @@ use Munus\Control\Option;
 use Munus\Exception\UnsupportedOperationException;
 use Munus\Value;
 use Munus\Value\Comparator;
+use ReturnTypeWillChange;
 
 /**
  * An abstraction for inherently recursive, multi-valued data structures. The order of elements is determined by
@@ -300,6 +301,7 @@ abstract class Traversable extends Value implements \IteratorAggregate
     /**
      * @return Iterator<T>
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->iterator();


### PR DESCRIPTION
This addition accommodates the introduction of 'native' return types in newer PHP versions. Once support for lower PHP versions is discontinued, this attribute can be safely removed along with the addition of return types.

Unfortunately, without this solution we can not use [PHP Opcache Preloading](https://www.php.net/manual/en/opcache.preloading.php) together with [Symfony's Tooling](https://symfony.com/blog/php-preloading-and-symfony). 

See, as an example, the following output of PHP-FPM starting and trying to run the preload script:
```
[03-Mar-2024 15:29:49] NOTICE: [pool www] 'group' directive is ignored when FPM is not running as root
[03-Mar-2024 15:29:49] NOTICE: fpm is running, pid 1
[03-Mar-2024 15:29:49] NOTICE: ready to handle connections
[03-Mar-2024 15:30:05] NOTICE: Reloading in progress ...
[03-Mar-2024 15:30:05] NOTICE: reloading: execvp("php-fpm", {"php-fpm"})
[03-Mar-2024 15:30:05 UTC] PHP Fatal error: During inheritance of Iterator: Uncaught ErrorException: Return type of Munus\Collection\Iterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/munusphp/munus/src/Collection/Iterator.php:108
Stack trace:
#0 /app/vendor/munusphp/munus/src/Collection/Iterator.php(15): Symfony\Component\DependencyInjection\Dumper\Preloader::Symfony\Component\DependencyInjection\Dumper\{closure}(8192, 'Return type of ...', '/app/vendor/mun...', 108)
#1 /app/vendor/composer/ClassLoader.php(576): include('/app/vendor/mun...')
#2 /app/vendor/composer/ClassLoader.php(427): Composer\Autoload\{closure}('/app/vendor/com...')
#3 [internal function]: Composer\Autoload\ClassLoader->loadClass('Munus\\Collectio...')
#4 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(80): class_exists('Munus\\Collectio...')
#5 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(125): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Munus\\Collectio...', Array)
#6 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(110): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
#7 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(125): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Munus\\Control\\O...', Array)
#8 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(110): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
#9 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(125): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Transip\\Fronten...', Array)
#10 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(107): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
#11 /app/vendor/symfony/dependency-injection/Dumper/Preloader.php(59): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Transip\\Fronten...', Array)
#12 /tmp/frontend/cache/prod/App_KernelProdContainer.preload.php(1999): Symfony\Component\DependencyInjection\Dumper\Preloader::preload(Array)
#13 /app/config/preload.php(28): require('/tmp/frontend/c...')
#14 /app/config/preload.php(12): doPreload('/tmp/frontend/c...', '/App_KernelProd...')
#15 {main} in /app/vendor/munusphp/munus/src/Collection/Iterator.php on line 15
```